### PR TITLE
Fix Load tag not working

### DIFF
--- a/Keyed/Menus_Main.xml
+++ b/Keyed/Menus_Main.xml
@@ -6,7 +6,7 @@
   <NewColony>Nowa kolonia</NewColony>
   <BackToGame>Wróć do gry</BackToGame>
   <Save>Zapisz</Save>
-  <Load>Wczytaj</Load>
+  <LoadGame>Wczytaj</LoadGame>
   <Options>Opcje</Options>
   <Mods>Modyfikacje</Mods>
   <Credits>Autorzy</Credits>


### PR DESCRIPTION
Tag Load został zastąpiony tagiem LoadGame, szybka poprawka która usunie z głównego menu brak polskiego napisu.