### PR TITLE
Stal, metal, superstal, plastal

### DIFF
--- a/DefInjected/ConceptDef/Concepts_NotedSelfshow.xml
+++ b/DefInjected/ConceptDef/Concepts_NotedSelfshow.xml
@@ -29,7 +29,7 @@
     	<Alerts.helpText>Alarmy w prawym rogu ekranu informują o problemach, które wymagają twojej uwagi.\n\nZwracaj na nie uwagę!</Alerts.helpText>
 
     	<Mining.label>kopanie</Mining.label>
-    	<Mining.helpText>Możesz wyznaczyć miejsce do kopania przez menu Architekta i zakładkę "polecenia".\n\nNiektóre skały zawierają stal, złoto, superstal i inne użyteczne materiały.</Mining.helpText>
+    	<Mining.helpText>Możesz wyznaczyć miejsce do kopania przez menu Architekta i zakładkę "polecenia".\n\nNiektóre skały zawierają metal, złoto, superstal i inne użyteczne materiały.</Mining.helpText>
 
     	<WorkTab.label>przegląd pracy</WorkTab.label>
     	<WorkTab.helpText>Możesz zmienić przydział prac każdego kolonisty w zakładce "praca" w lewym dolnym rogu ekranu.\n\nKoloniści będą zawsze wykonywać pracę o najwyższym priorytecie.\n\nPraca nigdy nie zostanie wykonana, jeśli nikt nie nie zostanie przydzielony lub wszyscy będą zajęci wykonywaniem zadań o wyższym priorytecie.</WorkTab.helpText>

--- a/DefInjected/InstructionDef/Instructions.xml
+++ b/DefInjected/InstructionDef/Instructions.xml
@@ -69,8 +69,8 @@
     <AddBillSimpleMeal.rejectInputMessage>Dodaj zlecenie gotowania prostych posiłków do Twojego pieca.</AddBillSimpleMeal.rejectInputMessage>
     <AddBillSimpleMeal.onMapInstruction>Wybierz to.</AddBillSimpleMeal.onMapInstruction>
 
-    <MineSteel.text>Teraz koloniści mogą gotować! Pysznie!\n\nNastępnie będziesz potrzebował nieco surowców. Stworzyłem nieco stali możliwej do wydobycia w pobliżu Twojej bazy.\n\nWybierz znacznik "Kop" i wskaż nim obszar stali, aby ją wykopać.</MineSteel.text>
-    <MineSteel.rejectInputMessage>Użyj znacznika "Kop" na stali.</MineSteel.rejectInputMessage>
+    <MineSteel.text>Teraz koloniści mogą gotować! Pysznie!\n\nNastępnie będziesz potrzebował nieco surowców. Stworzyłem nieco sprasowanego żelaza możliwego do wydobycia w pobliżu Twojej bazy.\n\nWybierz znacznik "Kop" i wskaż nim obszar żelaza, aby wykopać metal.</MineSteel.text>
+    <MineSteel.rejectInputMessage>Użyj znacznika "Kop" na sprasowanym żelazie.</MineSteel.rejectInputMessage>
     <MineSteel.onMapInstruction>Oznacz to wszystko do kopania.</MineSteel.onMapInstruction>
 
     <ChopTrees.text>Będziesz chciał zebrać nieco drewna. Oznacz nieco drzew do ścięcia.\n\nWybierz znacznik "Rąb drzewo" i wyznacz 10 drzew do ścięcia.\n\n(Wskazówka: możesz zaznaczyć pole, aby wyznaczyć na nim kilka drzew do ścięcia jednocześnie).</ChopTrees.text>

--- a/DefInjected/ResearchProjectDef/ResearchProjects_Tier4_Misc.xml
+++ b/DefInjected/ResearchProjectDef/ResearchProjects_Tier4_Misc.xml
@@ -20,7 +20,7 @@
     <Cryptosleep.description>Pozwala kolonistom budować kapsuły hibernacyjne, w których można umieścić żyjące istoty w stanie zawieszenia czynności życiowych.</Cryptosleep.description>
     
     <PoweredArmor.label>pancerz wspomagany</PoweredArmor.label>
-    <PoweredArmor.description>Neuromemetyczna robotyka i zaawansowane technologie tkackie z plastali pozwalają zbudować wspomagany pancerz i wspomagane hełmy.</PoweredArmor.description>
+    <PoweredArmor.description>Neuromemetyczna robotyka i zaawansowane technologie tkackie z superstali pozwalają zbudować wspomagany pancerz i wspomagane hełmy.</PoweredArmor.description>
     
     <ChargedShot.label>strzał energetyczny</ChargedShot.label>
     <ChargedShot.description>Poznaj tajniki energii pulsacyjnej i potrzebnych amunicji. Pozwala na budowę karabinów.</ChargedShot.description>


### PR DESCRIPTION
Słowo "steel" w większości spolszczenia przetłumaczono na "metal". Dziwnie wyglada "kawał stali" gdzie pozniej w grze przetapiasz go na metal. Uznalem ze warto to poprawic.