### PR TITLE
Change Command[Hide/Unhide]ZoneLabel keys to Command[Hide/Unhide]Label.

### DIFF
--- a/Core/Keyed/GameplayCommands.xml
+++ b/Core/Keyed/GameplayCommands.xml
@@ -110,9 +110,10 @@
   <CommandDetonateDesc>Rozpocznij odliczanie do detonacji.</CommandDetonateDesc>
 
   <!-- EN: Hide -->
-  <CommandHideZoneLabel>Ukryj</CommandHideZoneLabel>
+  <CommandHideLabel>Ukryj</CommandHideLabel>
   <!-- EN: Unhide -->
-  <CommandUnhideZoneLabel>Pokaż</CommandUnhideZoneLabel>
+  <CommandUnhideLabel>Pokaż</CommandUnhideLabel>
+  
   <!-- EN: Hide/unhide this zone. -->
   <CommandHideZoneDesc>Pokaż/ukryj tę strefę.</CommandHideZoneDesc>
 


### PR DESCRIPTION
CommandHideZoneLabel and CommandUnhideZoneLabel are not longer used. Replaced with CommandHideLabel key.

Before:
<img width="556" height="219" alt="image" src="https://github.com/user-attachments/assets/a1b6a994-627b-4be8-afe3-3efff060a2d6" />

After:
<img width="573" height="192" alt="image" src="https://github.com/user-attachments/assets/cbeffdca-3267-4d8d-b080-a855573c80cf" />
